### PR TITLE
Reset metrics after successful connection

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -1524,6 +1524,10 @@ extern "C" {
         if (event != NULL) {
             enet_protocol_change_state(host, peer, ENET_PEER_STATE_CONNECTED);
 
+            peer->totalDataSent = 0;
+            peer->totalDataReceived = 0;
+            peer->totalPacketsSent = 0;
+            peer->totalPacketsLost = 0;
             event->type = ENET_EVENT_TYPE_CONNECT;
             event->peer = peer;
             event->data = peer->eventData;


### PR DESCRIPTION
Small fix for the metrics which was introduced in https://github.com/zpl-c/enet/commit/9e0c7b4d541a4b8bee0674b192269348cc42f458 and https://github.com/zpl-c/enet/commit/994745916fced751e1e2c44adac5bea849720487 commits.