### PR TITLE
Fixed WSASend returning 1 instead of -1 on error.

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -5740,7 +5740,7 @@ extern "C" {
             NULL,
             NULL) == SOCKET_ERROR
         ) {
-            return (WSAGetLastError() == WSAEWOULDBLOCK) ? 0 : 1;
+            return (WSAGetLastError() == WSAEWOULDBLOCK) ? 0 : -1;
         }
 
         return (int) sentLength;


### PR DESCRIPTION
Fixed WSASend returning 1 instead of -1 on error.
Bug found by @c6burns