### PR TITLE
disable `#pragma comment(lib, ...)` macros when compiling with GCC under Windows

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -72,8 +72,10 @@
     #endif
 
     #ifndef ENET_NO_PRAGMA_LINK
+    #ifndef  __GNUC__
     #pragma comment(lib, "ws2_32.lib")
     #pragma comment(lib, "winmm.lib")
+    #endif
     #endif
 
     #if _MSC_VER >= 1910


### PR DESCRIPTION
if someone tries to use ENET with GCC under Windows, GCC returns this warning:

`-Wunknown-pragmas`.

according to the condition here, if compiling on a Windows machine, the `#pragma comment....` commands are says to the compiler.
but GCC (MinGW, MSYS2 etc.) has no support for this pragma.

the current condition is:

```
if windows
if not gcc
	pragmas
```
