### PR TITLE
Replace memset with {0}

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -5796,7 +5796,7 @@ extern "C" {
 
     int enet_initialize(void) {
         WORD versionRequested = MAKEWORD(1, 1);
-        WSADATA wsaData;
+        WSADATA wsaData = {0};
 
         if (WSAStartup(versionRequested, &wsaData)) {
             return -1;
@@ -5890,8 +5890,7 @@ extern "C" {
     }
 
     int enet_socket_bind(ENetSocket socket, const ENetAddress *address) {
-        struct sockaddr_in6 sin;
-        memset(&sin, 0, sizeof(struct sockaddr_in6));
+        struct sockaddr_in6 sin = {0};
         sin.sin6_family = AF_INET6;
 
         if (address != NULL) {
@@ -5908,7 +5907,7 @@ extern "C" {
     }
 
     int enet_socket_get_address(ENetSocket socket, ENetAddress *address) {
-        struct sockaddr_in6 sin;
+        struct sockaddr_in6 sin = {0};
         int sinLength = sizeof(struct sockaddr_in6);
 
         if (getsockname(socket, (struct sockaddr *) &sin, &sinLength) == -1) {
@@ -5994,10 +5993,8 @@ extern "C" {
     }
 
     int enet_socket_connect(ENetSocket socket, const ENetAddress *address) {
-        struct sockaddr_in6 sin;
+        struct sockaddr_in6 sin = {0};
         int result;
-
-        memset(&sin, 0, sizeof(struct sockaddr_in6));
 
         sin.sin6_family     = AF_INET6;
         sin.sin6_port       = ENET_HOST_TO_NET_16(address->port);
@@ -6014,7 +6011,7 @@ extern "C" {
 
     ENetSocket enet_socket_accept(ENetSocket socket, ENetAddress *address) {
         SOCKET result;
-        struct sockaddr_in6 sin;
+        struct sockaddr_in6 sin = {0};
         int sinLength = sizeof(struct sockaddr_in6);
 
         result = accept(socket, address != NULL ? (struct sockaddr *)&sin : NULL, address != NULL ? &sinLength : NULL);
@@ -6043,12 +6040,10 @@ extern "C" {
     }
 
     int enet_socket_send(ENetSocket socket, const ENetAddress *address, const ENetBuffer *buffers, size_t bufferCount) {
-        struct sockaddr_in6 sin;
-        DWORD sentLength;
+        struct sockaddr_in6 sin = {0};
+        DWORD sentLength=0;
 
         if (address != NULL) {
-            memset(&sin, 0, sizeof(struct sockaddr_in6));
-
             sin.sin6_family     = AF_INET6;
             sin.sin6_port       = ENET_HOST_TO_NET_16(address->port);
             sin.sin6_addr       = address->host;
@@ -6073,8 +6068,8 @@ extern "C" {
 
     int enet_socket_receive(ENetSocket socket, ENetAddress *address, ENetBuffer *buffers, size_t bufferCount) {
         INT sinLength = sizeof(struct sockaddr_in6);
-        DWORD flags   = 0, recvLength;
-        struct sockaddr_in6 sin;
+        DWORD flags   = 0, recvLength = 0;
+        struct sockaddr_in6 sin = {0};
 
         if (WSARecvFrom(socket,
             (LPWSABUF) buffers,


### PR DESCRIPTION
Initializing to 0 with {0} is considered a better practice. Safe and allows the compiler to perform the best optimization it can.

Right now I'm on Window and didn't do the Linux part of codes because I wish to ensure it work. There appears to be no issue at all with these change here.