### PR TITLE
Should we be nullifying the pointer after it's free?

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -1306,7 +1306,7 @@ extern "C" {
 
     void enet_free(void *memory) {
         callbacks.free(memory);
-        memory = nullptr;
+        memory = NULL;
     }
 
 // =======================================================================//

--- a/include/enet.h
+++ b/include/enet.h
@@ -1306,6 +1306,7 @@ extern "C" {
 
     void enet_free(void *memory) {
         callbacks.free(memory);
+        memory = nullptr;
     }
 
 // =======================================================================//


### PR DESCRIPTION
Small question, big thoughts.

I trust that this software is reliable. But I do see that pointers aren't being nullified here. So it's a bit of the headscratcher for me. I'll leave this to the judgment of the author.

I like performance, so having less code is always a plus. But I also value security.