### PR TITLE
Nullifying pointer actually not good?

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -1318,7 +1318,6 @@ extern "C" {
 
     void enet_free(void *memory) {
         callbacks.free(memory);
-        memory = NULL;
     }
 
 // =======================================================================//


### PR DESCRIPTION
This was confusing for my C++ brain. The addition I made here where you nullify pointer after freeing memory does absolutely nothing because the function takes a copy of a pointer. I'm used to thinking reference hence the mistake.

However, there are other confusion to this. I realized that actually nullifying pointer can cause program to crash rather than be stable. Take this example:

case ENET_EVENT_TYPE_DISCONNECT:
if constexpr (Server) {
     deactivatePlayer(event.peer->incomingPeerID+1);
     printf("Client%u has disconnected\n", event.peer->incomingPeerID+1);
     if (event.peer) {
         enet_peer_reset(event.peer);  // Reset peer safely
        //event.peer = nullptr;          // Ensure we don't use it again. But this cause crashes???
     }
     BitWriter ms(packet_buffer, MESSAGE_SYSTEM_SERVERMESSAGE);
     ms & "Player has disconnected!";
      message_relay(event, ms, NET_CHANNEL_SYSTEM_SECURE);
}

One would want to send out message of a player leaving. So you would reset the peer thinking it should render it destroyed. My message_relay() would go through a loop and acquire the peer from the host. Not the event. and check with currentpeer->state == ENET_PEER_STATE_CONNECTED.

If you uncomment the nullification of event's pointer to peer this would crash. I don't understand how, but event's peer and host's peer somehow shared the same peer? So if you nullify one from event it applies to host too! This is very counter intuitive I would say. Are we not supposed to nullify them at all? I'm guessing that to be the case.