### PR TITLE
Supporting dependency injection via direct use of external socket.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "enet.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "enet.h": "c"
-    }
-}

--- a/include/enet.h
+++ b/include/enet.h
@@ -4526,7 +4526,7 @@ extern "C" {
         #else
             int type;
             socklen_t len = sizeof(type);
-            if (getsockopt(socket, SOL_SOCKET, SO_TYPE, &type, &len) == 0) {
+            if (getsockopt(*socket, SOL_SOCKET, SO_TYPE, &type, &len) == 0) {
                 return (type == SOCK_DGRAM);
             }
         #endif

--- a/test/build.c
+++ b/test/build.c
@@ -74,7 +74,7 @@ int main() {
 
     /* create a server */
     printf("starting server...\n");
-    server = enet_host_create(&address, MAX_CLIENTS, 2, 0, 0);
+    server = enet_host_create(&address, MAX_CLIENTS, 2, 0, 0, NULL);
     if (server == NULL) {
         printf("An error occurred while trying to create an ENet server host.\n");
         return 1;
@@ -83,7 +83,7 @@ int main() {
     printf("starting clients...\n");
     for (i = 0; i < MAX_CLIENTS; ++i) {
         enet_address_set_host(&address, "127.0.0.1");
-        clients[i].host = enet_host_create(NULL, 1, 2, 0, 0);
+        clients[i].host = enet_host_create(NULL, 1, 2, 0, 0, NULL);
         clients[i].peer = enet_host_connect(clients[i].host, &address, 2, 0);
         if (clients[i].peer == NULL) {
             printf("coundlnt connect\n");

--- a/test/cli-server.c
+++ b/test/cli-server.c
@@ -38,7 +38,7 @@ void run_server() {
     address.host = ENET_HOST_ANY;
     address.port = 1234;
 
-    ENetHost* host = enet_host_create(&address, 4, 1, 0, 0);
+    ENetHost* host = enet_host_create(&address, 4, 1, 0, 0, NULL);
 
     if (!host) {
         printf("Failed to create server\n");
@@ -97,7 +97,7 @@ void run_client() {
     address.host = ENET_HOST_ANY;
     address.port = 1234;
 
-    ENetHost* host = enet_host_create(NULL, 1, 1, 0, 0);
+    ENetHost* host = enet_host_create(NULL, 1, 1, 0, 0, NULL);
 
     enet_address_set_host(&address, "127.0.0.1");
     address.port = 1234;


### PR DESCRIPTION
Direct response to feature request:

I added two things. A function: is_udp_socket(socket) to ensure it's UDP. and a bool ownsSocket as part of ENetHost to ensure it behave with internal mechanism for socket or to use external without creating or closing socket or changing the configuration of it. (Leaving it all to the implementer of their own network.)

You use your own socket by putting it in the new argument of enet_host_create() ENetSocket* externalUDPSocket.

You set it to NULL to use the internal socket as normally done.

This should theoretically work and will not break anything except you now need to fill in extra parameter. I am unable to test it for myself because I don't need to make my own network so I'm not sure how to do it either.

Things to test:
Use of external socket should work.
is_udp_socket should be valid.
External socket should only be managed by the programmer.