### PR TITLE
Upgrade CMake min ver to 3.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 project(enet C)
 
 # -----------------------------


### PR DESCRIPTION
## What
This upgrades the CMake minimum version to 3.13.

## Why
Version 3.0 is no longer supported by newer toolchains and fails to build.

## Exhibit
```
[cmake] CMake Error at vendor/enet/CMakeLists.txt:1 (cmake_minimum_required):
[cmake]   Compatibility with CMake < 3.5 has been removed from CMake.
[cmake] 
[cmake]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[cmake]   to tell CMake that the project requires at least <min> but has been updated
[cmake]   to work with policies introduced by <max> or earlier.
[cmake] 
[cmake]   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
```

## Considerations
While upgrading to something barely above 3.5+ to satisfy the requirements would work, there has been a similar upgrade done recently in CGLM (see https://github.com/recp/cglm/pull/430) from `3.8.2` to `3.13.0` and provides a lot more context why specifically `3.13.0` is more desirable. The defaults with set()/option() are less surprising and don't risk breaking backwards compatibility as something far newer could.