### PR TITLE
Fix conflict clock_gettime function on windows.

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -5060,7 +5060,7 @@ extern "C" {
             t.QuadPart |= f.dwLowDateTime;
             return (t);
         }
-        int _clock_gettime(int X, struct timespec *tv) {
+        static int _clock_gettime(int X, struct timespec *tv) {
             (void)X;
             LARGE_INTEGER t;
             FILETIME f;

--- a/include/enet.h
+++ b/include/enet.h
@@ -5055,6 +5055,7 @@ extern "C" {
             t.QuadPart |= f.dwLowDateTime;
             return (t);
         }
+        #ifndef WIN_PTHREADS_TIME_H
         int clock_gettime(int X, struct timespec *tv) {
             (void)X;
             LARGE_INTEGER t;
@@ -5093,6 +5094,7 @@ extern "C" {
             tv->tv_nsec = t.QuadPart % 1000000 * 1000;
             return (0);
         }
+        #endif
     #elif __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
         #define CLOCK_MONOTONIC 0
 

--- a/include/enet.h
+++ b/include/enet.h
@@ -5036,7 +5036,12 @@ extern "C" {
 // !
 // =======================================================================//
 
+    #define internal_clock_gettime clock_gettime
+
     #ifdef _WIN32
+        #undef internal_clock_gettime
+        #define internal_clock_gettime _clock_gettime
+
         static LARGE_INTEGER getFILETIMEoffset() {
             SYSTEMTIME s;
             FILETIME f;
@@ -5055,8 +5060,7 @@ extern "C" {
             t.QuadPart |= f.dwLowDateTime;
             return (t);
         }
-        #ifndef WIN_PTHREADS_TIME_H
-        int clock_gettime(int X, struct timespec *tv) {
+        int _clock_gettime(int X, struct timespec *tv) {
             (void)X;
             LARGE_INTEGER t;
             FILETIME f;
@@ -5094,11 +5098,10 @@ extern "C" {
             tv->tv_nsec = t.QuadPart % 1000000 * 1000;
             return (0);
         }
-        #endif
     #elif __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
         #define CLOCK_MONOTONIC 0
 
-        int clock_gettime(int X, struct timespec *ts) {
+        static int clock_gettime(int X, struct timespec *ts) {
             clock_serv_t cclock;
             mach_timespec_t mts;
 
@@ -5128,9 +5131,9 @@ extern "C" {
 
         struct timespec ts;
     #if defined(CLOCK_MONOTONIC_RAW)
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+        internal_clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
     #else
-        clock_gettime(CLOCK_MONOTONIC, &ts);
+        internal_clock_gettime(CLOCK_MONOTONIC, &ts);
     #endif
 
         static const uint64_t ns_in_s = 1000 * 1000 * 1000;

--- a/include/enet.h
+++ b/include/enet.h
@@ -5101,7 +5101,7 @@ extern "C" {
     #elif __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
         #define CLOCK_MONOTONIC 0
 
-        static int clock_gettime(int X, struct timespec *ts) {
+        int clock_gettime(int X, struct timespec *ts) {
             clock_serv_t cclock;
             mach_timespec_t mts;
 


### PR DESCRIPTION
## What
This renames the function clock_gettime only on windows.

# Why
On windows, enet provides its own implementation of `clock_gettime()` conditional to `#ifdef _WIN32`.

The problem is that the library `winpthreads` also provides a function also named clock_gettime() in `pthread_time.h`:
https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/include/pthread_time.h#L88

So if you happen to have `#include <pthread.h>` or `-lpthread` in a project compiled on windows, with mingw+winpthreads, while also useing enet, you get either conflicting declarations, definitions or symbols.

## How
I've added a macro alias `internal_clock_gettime` that defaults to `clock_gettime` to maintain the existing behavior on other platforms and gets overriden on windows specifically for `_clock_gettime`. It is `static` because C gives internal linkage to functions begining with an underscore, which is what we want for symbols in this TU to avoid colliding accidently outside the library.