### PR TITLE
Fix UB in check_timeouts shift and CRC reflect

### DIFF
--- a/include/enet.h
+++ b/include/enet.h
@@ -1545,10 +1545,11 @@ extern "C" {
     static enet_uint32 crcTable[256];
 
     static enet_uint32 reflect_crc(int val, int bits) {
-        int result = 0, bit;
+        enet_uint32 result;
+        int bit;
 
         for (bit = 0; bit < bits; bit++) {
-            if (val & 1) { result |= 1 << (bits - 1 - bit); }
+            if (val & 1) { result |= 1u << (bits - 1 - bit); }
             val >>= 1;
         }
 
@@ -2969,7 +2970,7 @@ extern "C" {
 
             if (peer->earliestTimeout != 0 &&
                 (ENET_TIME_DIFFERENCE(host->serviceTime, peer->earliestTimeout) >= peer->timeoutMaximum ||
-                ((1u << (outgoingCommand->sendAttempts - 1)) >= peer->timeoutLimit &&
+                (outgoingCommand->sendAttempts > 32 || (1u << (outgoingCommand->sendAttempts - 1)) >= peer->timeoutLimit &&
                 ENET_TIME_DIFFERENCE(host->serviceTime, peer->earliestTimeout) >= peer->timeoutMinimum))
             ) {
                 enet_protocol_notify_disconnect_timeout(host, peer, event);


### PR DESCRIPTION
I made bindings of this library for the the Zig language and found out that it sometimes crashed. Zig detects unsigned out of bounds shifts in debug builds:

```
thread 36633 panic: shift exponent 32 is too large for 32-bit type 'unsigned int'
zig-pkg/N-V-__8AAJZTBQAYHEqBtyGRzh0esiAmJEjYMWoX8BNgTeov/include/enet.h:2972:22: 0x212e60a in enet_protocol_check_timeouts (/home/pivok/Dev/PiVoxel/zig-pkg/enet-2.7.0-FcQynOt5AAAreHzvVVZ9Em6Q3wJm6is-1vsG4NV8kjvA/src/enet.c)
                ((1u << (outgoingCommand->sendAttempts - 1)) >= peer->timeoutLimit &&
```

Two UB shift fixes:
1. enet_protocol_check_timeouts: sendAttempts is an unbounded enet_uint16 used as the exponent in 1u << (sendAttempts - 1). When sendAttempts reaches 33, the shift by 32 overflows unsigned int (UB). Under heavy load with a low-RTT peer, sendAttempts can grow past 32 before timeoutMinimum fires.
2. This one is just something i found out by looking for other UB shifts and it didn't acrually crash my program. reflect_crc: with bits=32, the expression `1 << (bits - 1 - bit)` evaluates to `1 << 31` which overflows signed int (UB). Use `1u` for a well-defined unsigned shift.